### PR TITLE
Fix $XDG_CONFIG_HOME typo in README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -12,7 +12,7 @@ patterns to match all log lines which are not interesting, and then prints all
 log lines not matching those patterns (or sends them by mail).
 
 When you start it the first time, it'll write the default pattern and config to
-`$XDG_CONFIG_HOME/.config/journalwatch` (`$XDG_CONFIG_HOME` is your home if
+`$XDG_CONFIG_HOME/journalwatch` (`$XDG_CONFIG_HOME` is `$HOME/.config` if
 unset). Details on how to configure journalwatch are available in these files.
 
 Dependencies


### PR DESCRIPTION
Match the README description of `$XDG_CONFIG_HOME` to the implementation (and to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables)).