### PR TITLE
Ensure to always compare string representation.

### DIFF
--- a/journalwatch.py
+++ b/journalwatch.py
@@ -299,10 +299,10 @@ def filter_message(patterns, entry):
         # Now check if the message key matches the key we're currently looking
         # at
         if hasattr(v, 'match'):
-            if not v.match(entry[k]):
+            if not v.match(str(entry[k])):
                 continue
         else:
-            if entry[k] != v:
+            if str(entry[k]) != v:
                 continue
         # If we arrive here, the keys matched so we need to check these
         # patterns.


### PR DESCRIPTION
This is especially important when trying to match the PRIORITY field.

Consider for example the following pattern, which does not work for me without this patch:

```
# Ignore non-error priorities
PRIORITY = /(7|6|5|4)/
.*
```