### PR TITLE
Add --priority [0<INT<8] command line option

### DIFF
--- a/journalwatch.py
+++ b/journalwatch.py
@@ -181,7 +181,7 @@ def parse_args():
                         "new: Process everything new since the last "
                         "invocation.\n"
                         "<n>: Process everything in the past <n> seconds.\n")
-    parser.add_argument('--priority', type=int, nargs='?', 
+    parser.add_argument('--priority', nargs='?', 
                         help="Lowest priority of message to be considered.\n"
                         "A number between 7 (debug), and 1 (emergency).")
     parser.add_argument('--loglevel', nargs='?', 
@@ -377,15 +377,15 @@ def get_journal(since=None, priority=None):
                If None, the whole journal is read.
         priority: A number between 1 and 7 for lowest priority
                to consider.
-               If omited, defaults to "LOG_INFO", number 6.
+               If omitted, defaults to "LOG_INFO", number 6.
     """
     j = journal.Reader()
-    if (int(priority) < 1):
-        j.log_level(1)
-    elif (int(priority) >= 1 and int(priority) <= 7):
-        j.log_level(int(priority))
-    else:
-        j.log_level(7)
+    try:
+        priority = int(priority)
+    except ValueError:
+        raise JournalWatchError("Priority level invalid: '{}'".format(config.priority))
+    priority = max(1, min(priority, 7))
+    j.log_level(priority)
     if since is not None:
         j.seek_realtime(since)
     else:


### PR DESCRIPTION
Hi Florian,

Hope you don't mind me proposing a small change I find useful to journalwatch – a little program I already find very useful as it is!
This change would allow the user to select the journald log_level under which log messages should not be considered. The option is called "--priority", and takes an integer between 1 (only critical messages) and 7 (all messages up to debug).
This was previously hard coded to LOG_INFO level (number 6) in line 375: 
````
j.log_level(journal.LOG_INFO)
````
I have honored the previous default by using config default and setting it at 6.
I find this useful as level 6 messages on my system are mostly noise, and it would require a great many patterns to be written, some of them very wide (ex: ".*id.*") in order to clean the emails up.

I have also somewhat clarified the help message concerning the "--loglevel" command line option,
which refers to the log level of journalwatch's own messages, and could well be confused with the new "--priority" option.
Hope there are no issues with the code… Let me know if there are.
Regards,
Mark.