### PR TITLE
use fullmatch and document that

### DIFF
--- a/journalwatch.py
+++ b/journalwatch.py
@@ -75,8 +75,8 @@ DEFAULT_PATTERNS = r"""
 # Lines starting with '#' are comments. Inline-comments are not permitted.
 #
 # The patterns are separated into blocks delimited by empty lines. Each block
-# matches on a log entry field, and the patterns in that block then are matched
-# against all messages with a matching log entry field.
+# matches on exactly one log entry field, and the patterns in that block then
+# are matched against all messages with a matching log entry field.
 #
 # The syntax of a block looks like this:
 #
@@ -87,7 +87,8 @@ DEFAULT_PATTERNS = r"""
 #
 # If <value> starts and ends with a slash, it is interpreted as a regular
 # expression, if not, it's an exact match. Patterns are always regular
-# expressions.
+# expressions.  All regular expressions have to match the full string,
+# i.e., they start with an implicit "^" and end with "$".
 #
 # Below are some useful examples. If you have a small set of users, you might
 # want to adjust things like "user \w" to something like "user (root|foo|bar)".
@@ -320,8 +321,8 @@ def filter_message(patterns, entry):
             continue
         # Now check if the message key matches the key we're currently looking
         # at
-        if hasattr(v, 'match'):
-            if not v.match(str(entry[k])):
+        if hasattr(v, 'fullmatch'):
+            if not v.fullmatch(str(entry[k])):
                 continue
         else:
             if str(entry[k]) != v:
@@ -329,7 +330,7 @@ def filter_message(patterns, entry):
         # If we arrive here, the keys matched so we need to check these
         # patterns.
         for filt in cur_patterns:
-            if filt.match(read_entry_message(entry)):
+            if filt.fullmatch(read_entry_message(entry)):
                 return True
     # No patterns on no key/value blocks matched.
     return False


### PR DESCRIPTION
Use fullmatch instead of match, to anchor the regexp both at the beginning and at the end of the string.

NOTE: *This is a behavioral change*. I do not know what your backwards compatibility story is. All the example patterns still seem fine, and the test suite still passes.

Considering the fact that some of the example patterns end with `.*` -- which is strictly redundant when using `match` -- my guess is that it was already supposed to match the entire line, and not just some prefix. I also think this makes more sense. However, if you prefer not to change the behavior, I can also submit a PR that documents the existing behavior (anchor in the beginning, but NOT in the end), and add `$` to most (all?) of the existing patterns.