### PR TITLE
CI: avoid code duplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ services:
   - docker
 env:
   - PYTHON=python3.5
+    DIST=ubuntu:xenial
   - PYTHON=python3.6
+    DIST=ubuntu:artful
 
 install:
-  - docker build -t journalwatch/ci ci/"$PYTHON"
+  - docker pull "$DIST"
 script:
-  - docker run -v $PWD:/build/ -e PYTHON="$PYTHON" journalwatch/ci /build/ci/run.sh
+  - docker run -v $PWD:/build/ -e PYTHON="$PYTHON" "$DIST" /build/ci/run.sh

--- a/ci/python3.5/Dockerfile
+++ b/ci/python3.5/Dockerfile
@@ -1,3 +1,0 @@
-FROM ubuntu:xenial
-
-RUN apt -qq update && apt install -y python3.5 python3-pip libsystemd-dev

--- a/ci/python3.6/Dockerfile
+++ b/ci/python3.6/Dockerfile
@@ -1,3 +1,0 @@
-FROM ubuntu:artful
-
-RUN apt -qq update && apt install -y python3.6 python3-pip libsystemd-dev

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -3,6 +3,8 @@ set -e
 set -x
 
 # Prepare the environment
+apt -qq update
+apt install -y "$PYTHON" python3-pip libsystemd-dev
 pip3 install --user systemd pytest
 
 # Run the tests


### PR DESCRIPTION
Just directly use the Ubuntu docker images and do the remaining setup in `run.sh`. Our derived images do not seem to have been cached anyway.