### PR TITLE
read_patterns: if a header occurs multiple times, merge its patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__
 # pytest's cache
 .cache
+# IDE
+/.idea/

--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,9 @@
 journalwatch
 ============
 
-journalwatch is a tool which can find error messages in the systemd
-journal.
+journalwatch is a tool which can find error messages in the systemd journal.
 
-It is similiar to tools like `logwatch <http://sourceforge.net/projects/logwatch/>`_
+It is similar to tools like `logwatch <http://sourceforge.net/projects/logwatch/>`_
 or `logcheck <http://logcheck.org/>`_ except it's much more KISS and only works
 with the systemd `journal <http://0pointer.de/blog/projects/journalctl.html>`_.
 It works by defining patterns to match all log lines which are not interesting,

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,9 @@ journalwatch
 
 journalwatch is a tool which can find error messages in the systemd journal.
 
-It is similar to tools like `logwatch <http://sourceforge.net/projects/logwatch/>`_
-or `logcheck <http://logcheck.org/>`_ except it's much more KISS and only works
-with the systemd `journal <http://0pointer.de/blog/projects/journalctl.html>`_.
+It is similar to tools like `logwatch <https://sourceforge.net/projects/logwatch/>`_
+or `logcheck <https://logcheck.org/>`_ except it's much more KISS and only works
+with the systemd `journal <https://0pointer.de/blog/projects/journalctl.html>`_.
 It works by defining patterns to match all log lines which are not interesting,
 and then prints all log lines not matching those patterns (or sends them by
 mail).
@@ -21,7 +21,7 @@ Dependencies
 -  Python 3 (mainly tested with 3.5, should work with >= 3.3)
 -  ``systemd`` python module
 -  ``setuptools``
--  A working ``sendmail``/MTA (`msmtp <http://msmtp.sourceforge.net/>`_
+-  A working ``sendmail``/MTA (`msmtp <https://msmtp.sourceforge.net/>`_
    is easy to set up)
 
 Development
@@ -48,4 +48,4 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
 Public License for more details.
 
 You should have received a copy of the GNU General Public License along
-with journalwatch. If not, see http://www.gnu.org/licenses/.
+with journalwatch. If not, see https://www.gnu.org/licenses/.

--- a/journalwatch.py
+++ b/journalwatch.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 # vim: set ft=python fileencoding=utf-8:
 
 # Copyright 2014 Florian Bruhin (The Compiler) <me@the-compiler.org>

--- a/journalwatch.py
+++ b/journalwatch.py
@@ -96,7 +96,7 @@ DEFAULT_PATTERNS = r"""
 #
 # https://docs.python.org/3.4/library/re.html#regular-expression-syntax
 # https://docs.python.org/3.4/howto/regex.html
-# http://doc.pyschools.com/html/regex.html
+# https://doc.pyschools.com/html/regex.html
 #
 # The journal fields are explained in systemd.journal-fields(7).
 

--- a/journalwatch.py
+++ b/journalwatch.py
@@ -3,6 +3,7 @@
 # vim: set ft=python fileencoding=utf-8:
 
 # Copyright 2014 Florian Bruhin (The Compiler) <me@the-compiler.org>
+# Copyright 2025 Daniel Langbein <daniel@systemli.org>
 #
 # journalwatch is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +21,7 @@
 """Filter error messages from systemd journal.
 
 Copyright 2014 Florian Bruhin (The Compiler) <me@the-compiler.org>
+Copyright 2025 Daniel Langbein <daniel@systemli.org>
 
 For bugs, feature requests or contributions, mail <me@the-compiler.org>.
 The newest version is available at https://g.cmpl.cc/journalwatch

--- a/journalwatch.py
+++ b/journalwatch.py
@@ -53,7 +53,7 @@ from datetime import datetime, timedelta
 from email.mime.text import MIMEText
 from email.generator import BytesGenerator
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 HOME = os.path.expanduser("~")
 XDG_DATA_HOME = os.environ.get("XDG_DATA_HOME",

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ def find_version(*file_paths):
 
 setup(
     name='journalwatch',
-    description="A tool to get notified on error messages in the systemd "
-                "journal",
+    description="A tool to get notified on error messages in the systemd journal",
     url='https://github.com/The-Compiler/journalwatch',
     author="Florian Bruhin",
     author_email='me@the-compiler.org',

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     name='journalwatch',
     description="A tool to get notified on error messages in the systemd journal",
     url='https://github.com/The-Compiler/journalwatch',
-    author="Florian Bruhin",
-    author_email='me@the-compiler.org',
+    author="Florian Bruhin, Daniel Langbein",
+    author_email='me@the-compiler.org, daniel@systemli.org',
     version=find_version('journalwatch.py'),
     py_modules=['journalwatch'],
     entry_points={

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  buildInputs = [
+    (pkgs.python3.withPackages (python-pkgs: with python-pkgs; [
+      systemd
+      setuptools
+      pytest
+    ]))
+  ];
+}

--- a/test_journalwatch.py
+++ b/test_journalwatch.py
@@ -63,12 +63,12 @@ def test_merge_patterns_with_same_header():
      'U foo : EMPTY!'),
 
     ({
-        '_SYSTEMD_UNIT': 'foo',
-        'PRIORITY': 'Prio',
-        '__REALTIME_TIMESTAMP': datetime.fromtimestamp(0, tz=timezone.utc),
-        '_PID': 1337,
-        'MESSAGE': "Hello World"
-    }, 'U Thu Jan  1 00:00:00 1970 pPrio foo [1337]: Hello World'),
+         '_SYSTEMD_UNIT': 'foo',
+         'PRIORITY': 'Prio',
+         '__REALTIME_TIMESTAMP': datetime.fromtimestamp(0, tz=timezone.utc),
+         '_PID': 1337,
+         'MESSAGE': "Hello World"
+     }, 'U Thu Jan  1 00:00:00 1970 pPrio foo [1337]: Hello World'),
 
     ({'SYSLOG_IDENTIFIER': 'sys', 'MESSAGE': "Hello World"},
      'S sys: Hello World'),
@@ -82,44 +82,44 @@ def test_format_entry(entry, expected):
     ({}, {'MESSAGE': 'foo'}, False),
     # No message
     (
-        {('_SYSLOG_IDENTIFIER', 'foo'): [re.compile('bar')]},
-        {'_SYSLOG_IDENTIFIER': 'foo'},
-        False
+            {('_SYSLOG_IDENTIFIER', 'foo'): [re.compile('bar')]},
+            {'_SYSLOG_IDENTIFIER': 'foo'},
+            False
     ),
     # No matching pattern
     (
-        {('_SYSLOG_IDENTIFIER', 'bar'): [re.compile('bar')]},
-        {'_SYSLOG_IDENTIFIER': 'foo', 'MESSAGE': 'unmatched'},
-        False
+            {('_SYSLOG_IDENTIFIER', 'bar'): [re.compile('bar')]},
+            {'_SYSLOG_IDENTIFIER': 'foo', 'MESSAGE': 'unmatched'},
+            False
     ),
     # Matching pattern
     (
-        {('_SYSLOG_IDENTIFIER', 'bar'): [re.compile('msg')]},
-        {'_SYSLOG_IDENTIFIER': 'bar', 'MESSAGE': 'msg'},
-        True
+            {('_SYSLOG_IDENTIFIER', 'bar'): [re.compile('msg')]},
+            {'_SYSLOG_IDENTIFIER': 'bar', 'MESSAGE': 'msg'},
+            True
     ),
     # Regex as identifier
     (
-        {('_SYSLOG_IDENTIFIER', re.compile('bar')): [re.compile('msg')]},
-        {'_SYSLOG_IDENTIFIER': 'bar', 'MESSAGE': 'msg'},
-        True
+            {('_SYSLOG_IDENTIFIER', re.compile('bar')): [re.compile('msg')]},
+            {'_SYSLOG_IDENTIFIER': 'bar', 'MESSAGE': 'msg'},
+            True
     ),
     # Matching priority (#7)
     (
-        {('PRIORITY', '1'): [re.compile('msg')]},
-        {'PRIORITY': 1, 'MESSAGE': 'msg'},
-        True
+            {('PRIORITY', '1'): [re.compile('msg')]},
+            {'PRIORITY': 1, 'MESSAGE': 'msg'},
+            True
     ),
     (
-        {('PRIORITY', re.compile('1')): [re.compile('msg')]},
-        {'PRIORITY': 1, 'MESSAGE': 'msg'},
-        True
+            {('PRIORITY', re.compile('1')): [re.compile('msg')]},
+            {'PRIORITY': 1, 'MESSAGE': 'msg'},
+            True
     ),
     # Binary message (#5)
     (
-        {('_SYSLOG_IDENTIFIER', 'bar'): [re.compile('msg')]},
-        {'_SYSLOG_IDENTIFIER': 'bar', 'MESSAGE': b'\xde\xad\xbe\xef'},
-        False
+            {('_SYSLOG_IDENTIFIER', 'bar'): [re.compile('msg')]},
+            {'_SYSLOG_IDENTIFIER': 'bar', 'MESSAGE': b'\xde\xad\xbe\xef'},
+            False
     ),
 ])
 def test_filter_message(patterns, entry, filtered):


### PR DESCRIPTION
While reading the patterns:
- If an identical header occurs multiple times, merge its pattern lists instead of silently keeping only the last list.
- An alternative would be to raise a configuration error.

This change has been added with the commit **"read_patterns: if a header occurs multiple times, merge its patterns"**, so ideally have a look at that first. Apart from that I've done some automatic formatting and smaller refactorings, e.g. changed "http" to "https" in the documentation. Lastly, I've included a "shell.nix" file for development on NixOS.

I'm looking forward to hear your feedback and hope you find some of these changes helpful. Please let me know if something should be changed before you want to merge.